### PR TITLE
parseInt to avoid string concatenation

### DIFF
--- a/src/components/number-spinner/index.js
+++ b/src/components/number-spinner/index.js
@@ -20,7 +20,7 @@ module.exports = require('marko-widgets').defineComponent({
         // in the state and that will be the current
         // integer value of the number spinner
         return {
-            value: value
+            value: parseInt(value)
         };
     },
     getTemplateData: function(state, input) {


### PR DESCRIPTION
FIX: when initialized using attribute
<number-spinner value="4"/>,
Marko considers the value as string and  '+' button uses concatenation
("4" + "1" = "41")
